### PR TITLE
Neovim

### DIFF
--- a/extras.sh
+++ b/extras.sh
@@ -50,6 +50,8 @@ function detect_pkg_manager () {
 	# debian
 	if [ -x "$(command -v apt-get)" ]; then
 		DOTFILES_PKG_MANAGER="apt-get"
+		apt-get update -y > /dev/null 2> /dev/null
+
 	# rhel
 	elif [ -x "$(command -v dnf)" ]; then
 		DOTFILES_PKG_MANAGER="dnf"
@@ -57,6 +59,7 @@ function detect_pkg_manager () {
 		source /etc/os-release
 		if [[ $ID == "rocky" ]]; then
 			DOTFILES_OS_RHEL=1
+			DOTFILES_OS_RHEL_VERSION="$(echo $PLATFORM_ID | awk -F: '{print $2}' | awk -Fl '{print $2}')"
 		else
 			DOTFILES_OS_RHEL=0
 		fi
@@ -159,6 +162,8 @@ function parse_subcommand () {
 			mod_omz $2 $3 $4
 			sleep .1
 			mod_neovim $2 $3 $4
+			sleep .1
+			mod_nvchad $2 $3 $4
 			;;
 
 		*)
@@ -390,15 +395,20 @@ function neovim_install () {
 	# RHEL systems require EPEL to be installed and CRB to be enabled
 	if [[ $DOTFILES_OS_RHEL == 1 ]]; then
 		./outputs.sh step "Installing the Extra Packages for Enterprise Linux (EPEL) repository - this is where Neovim is located"
-		sudo dnf install -y epel-release > /dev/null
+		sudo dnf install -y epel-release 2>&1 > /dev/null
 
 		./outputs.sh step "Enabling the CodeReady Builder (CRB) repository - required for many EPEL packages"
 		/usr/bin/crb enable > /dev/null
 	fi
 
-
-	./outputs.sh step "Installing Zsh using $DOTFILES_PKG_MANAGER"
-	sudo $DOTFILES_PKG_MANAGER install -y neovim > /dev/null
+	./outputs.sh step "Installing Neovim using $DOTFILES_PKG_MANAGER"
+	if [[ $DOTFILES_PKG_MANAGER == "zypper" ]]; then
+		# if opensuse, busybox-which conflicts with gnu-which required by neovim, so --force-resolution must be passed to force it to fix it
+		# ./outputs.sh step "Removing busybox-which, as it conflicts with gnu-which required by neovim"
+		sudo zypper install -y --force-resolution neovim > /dev/null 2> /dev/null
+	else
+		sudo $DOTFILES_PKG_MANAGER install -y neovim > /dev/null 2> /dev/null
+	fi
 
 	# touch a new .zshrc file temporarily to avoid missing file warning
 	# allows other errors to pass through if 
@@ -417,6 +427,103 @@ Commands:
 EOF
 	[[ "$1" == "-h" ]] && exit 0 || exit 1
 }
+
+
+# --------------------------------------
+
+function mod_nvchad () {
+	case $1 in
+	detect)
+		nvchad_detect
+		;;
+	
+	install)
+		nvchad_install
+		;;
+	
+	*)
+		nvchad_help $1
+
+	esac
+}
+
+
+function nvchad_detect () {
+	# is file and not link
+	if [ -f ~/.config/nvim/README.md ] && [ -L ~/.config/nvim/README.md ]; then
+		./outputs.sh status_good "NvChad install status" "already installed!"
+		DOTFILES_NVCHAD_INSTALLED=1
+	else
+		./outputs.sh status_bad "NvChad install status" "NOT installed."
+		DOTFILES_NVCHAD_INSTALLED=0
+	fi
+}
+
+
+function nvchad_install () {
+	./outputs.sh subheader "Installing NvChad"
+
+	local tempfold curdir nvim_pid av av_maj am_min av_bug
+
+	if [[ $DOTFILES_OS_RHEL == 1 ]]; then
+		av=$(dnf info neovim | grep 'Version' | awk -F: '{gsub(/ /, "", $2); print $2}')
+		av_maj=$(echo $av | awk -F. '{print $1}')
+		av_min=$(echo $av | awk -F. '{print $2}')
+		av_bug=$(echo $av | awk -F. '{print $3}')
+
+		if (( $av_maj < 1 )) && (( $av_min < 10 )); then
+			./outputs.sh status_bad "Latest Neovim version avaiable" "v$av"
+			echo -e "NvChad \e[31mcan't\e[0m be installed here, as it requires Neovim v0.10.0 or greater, but v$av is the latest version available for this system."
+
+			# without the lua folder present, quicksync will complain about a missing file in the user's home dir
+			./outputs.sh step "Creating ~/.config/nvim folder so quicksync.sh can shut up"
+			mkdir -p ~/.config/nvim/lua
+			return 1
+		else
+			./outputs.sh status_good "Latest Neovim version avaiable" "v$av"
+		fi
+	fi
+
+	nvchad_detect
+	if [[ $DOTFILES_NVCHAD_INSTALLED == 1 ]]; then
+		echo -e "\e[31mSkipping\e[0m NvChad installation."
+		return
+	fi
+	echo
+
+	# prep folders
+	# tempfold=$(mktemp -d)
+	# curdir=$(pwd)
+
+	# download nvchad repo
+	./outputs.sh step "Downloading NvChad starter config"
+	git clone https://github.com/NvChad/starter ~/.config/nvim > /dev/null 2> /dev/null
+
+	# let lazy.nvim download plugins
+	echo -e "You'll need to run \e[1;33mnvim\e[0m manually to let lazy.nvim download all its plugins."
+	echo -e "You'll also need to run \e[1;33m:MasonInstallAll\e[0m from within Neovim once that's done."
+	echo
+
+	rm -rf ~/.config/nvim/.git
+
+	./outputs.sh step "Linking customized NvChad configs"
+	$DOTFILES_DIR/quicksync.sh rm .config/nvim/lua -y > /dev/null
+	$DOTFILES_DIR/quicksync.sh ln .config/nvim/lua -y > /dev/null
+
+}
+
+
+function nvchad_help () {
+	cat << EOF
+$SHELL_SCRIPT_FILE_NAME nvchad [-h] <command>
+
+Commands:
+\`detect\`: Detect existing install and display its status
+\`install\`: Install NvChad
+EOF
+	[[ "$1" == "-h" ]] && exit 0 || exit 1
+}
+
 
 
 

--- a/testing-tools/Dockerfile.rocky
+++ b/testing-tools/Dockerfile.rocky
@@ -1,0 +1,9 @@
+FROM rockylinux:9.3
+
+RUN dnf update -y
+RUN dnf install -y --refresh git util-linux-user sudo
+# util-linux-user provides `chsh`
+
+ENV DOTFILES_DIR=/root/dotfiles
+
+WORKDIR ${DOTFILES_DIR}

--- a/testing-tools/Dockerfile.ubuntu
+++ b/testing-tools/Dockerfile.ubuntu
@@ -1,7 +1,9 @@
 FROM ubuntu:latest
 
 RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install -y git curl sudo language-pack-en
+RUN ln -fs /usr/share/zoneinfo/America/Denver /etc/localtime
+RUN apt-get install -y git curl sudo language-pack-en tzdata
+RUN dpkg-reconfigure -f noninteractive tzdata
 
 ENV DOTFILES_DIR=/root/dotfiles
 

--- a/testing-tools/test.sh
+++ b/testing-tools/test.sh
@@ -19,7 +19,7 @@ function build () {
 	
 	if [[ ${os_options[@]} =~ $1 ]]; then
 		echo "Building testing image for $1"
-		docker build -f Dockerfile.$1 --tag "dotfile-testing:$1" .
+		docker build $2 -f Dockerfile.$1 --tag "dotfile-testing:$1" .
 	else
 		echo "OS $1 is not in the list of known OSes. Known OSes: ${os_options[@]}"
 	fi
@@ -33,7 +33,7 @@ case $1 in
 		;;
 
 	build)
-		build $2
+		build $2 $3
 		;;
 
 	*)


### PR DESCRIPTION
Neovim and NvChad install automation

NvChad doesn't work on Ubuntu at the moment, becuase it requires Neovim v0.10.0 and v0.9.5 is the newest on any version of Ubuntu. 

It will check if you're using RHEL and not install NvChad if the Neovim version available is less than v0.10.0.